### PR TITLE
Bugfix: RPC call Getting empty response on compression enabled

### DIFF
--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -21,6 +21,7 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"math"
 	"reflect"
@@ -265,4 +266,134 @@ func BenchmarkGZIPCompressor512KiB(b *testing.B) {
 
 func BenchmarkGZIPCompressor1MiB(b *testing.B) {
 	bmCompressor(b, 1024*1024, NewGZIPCompressor())
+}
+func TestCheckReceiveMessageOverflow(t *testing.T) {
+	tests := []struct {
+		name                  string
+		readBytes             int64
+		maxReceiveMessageSize int64
+		dcReader              io.Reader
+		wantErr               error
+	}{
+		{
+			name:                  "No overflow",
+			readBytes:             5,
+			maxReceiveMessageSize: 10,
+			dcReader:              bytes.NewReader([]byte{}),
+			wantErr:               nil,
+		},
+		{
+			name:                  "Overflow with additional data",
+			readBytes:             10,
+			maxReceiveMessageSize: 10,
+			dcReader:              bytes.NewReader([]byte{1}),
+			wantErr:               errors.New("overflow: message larger than max size receivable by client (10 bytes)"),
+		},
+		{
+			name:                  "No overflow with EOF",
+			maxReceiveMessageSize: 10,
+			dcReader:              bytes.NewReader([]byte{}),
+			wantErr:               nil,
+		},
+		{
+			name:                  "Overflow condition with error handling",
+			readBytes:             15,
+			maxReceiveMessageSize: 15,
+			dcReader:              bytes.NewReader([]byte{1, 2, 3}),
+			wantErr:               errors.New("overflow: message larger than max size receivable by client (15 bytes)"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkReceiveMessageOverflow(tt.readBytes, tt.maxReceiveMessageSize, tt.dcReader)
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Errorf("unexpected error state: got err=%v, want err=%v", err, tt.wantErr)
+			} else if err != nil && err.Error() != tt.wantErr.Error() {
+				t.Errorf("unexpected error message: got err=%v, want err=%v", err, tt.wantErr)
+			}
+
+		})
+	}
+}
+
+type testCompressor struct {
+	triggerDecompressError bool
+}
+
+func (c *testCompressor) Name() string {
+	// Return a name for the compressor.
+	return "testCompressor"
+}
+
+func (c *testCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return nil, errors.New("Compress not implemented")
+}
+
+func (c *testCompressor) Decompress(r io.Reader) (io.Reader, error) {
+	if c.triggerDecompressError {
+		return nil, errors.New("decompression failed")
+	}
+	return r, nil
+}
+
+func (c *testCompressor) DecompressedSize(compressedBytes []byte) int {
+	return len(compressedBytes) * 2 // Assume decompressed size is double for testing
+}
+
+// TestDecompress tests the decompress function.
+func TestDecompress(t *testing.T) {
+	tests := []struct {
+		name                  string
+		compressor            *testCompressor
+		input                 []byte
+		maxReceiveMessageSize int
+		wantOutput            []byte
+		wantSize              int
+		wantErr               bool
+	}{
+		{
+			name:                  "Successful decompression",
+			compressor:            &testCompressor{},
+			input:                 []byte{0x01, 0x02, 0x03, 0x04},
+			maxReceiveMessageSize: 10,
+			wantOutput:            []byte{0x01, 0x02, 0x03, 0x04},
+			wantSize:              4,
+			wantErr:               false,
+		},
+		{
+			name:                  "Message size overflow",
+			compressor:            &testCompressor{},
+			input:                 []byte{0x01, 0x02, 0x03, 0x04},
+			maxReceiveMessageSize: 2,
+			wantOutput:            nil,
+			wantSize:              8,
+			wantErr:               true,
+		},
+		{
+			name:                  "Error during decompression",
+			compressor:            &testCompressor{triggerDecompressError: true},
+			input:                 []byte{0x01, 0x02, 0x03, 0x04},
+			maxReceiveMessageSize: 10,
+			wantOutput:            nil,
+			wantSize:              0,
+			wantErr:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, size, err := decompress(tt.compressor, tt.input, tt.maxReceiveMessageSize)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decompress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !bytes.Equal(output, tt.wantOutput) {
+				t.Errorf("decompress() got = %v, want %v", output, tt.wantOutput)
+			}
+			if size != tt.wantSize {
+				t.Errorf("decompress() size = %d, want %d", size, tt.wantSize)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Problem:

https://github.com/grpc/grpc-go/issues/4552 Get empty response when compress enabled and maxReceiveMessageSize be maxInt64 

### Action:

Added checking receive message size overflow checkReceiveMessageOverflow  in rpc_util.go and Implementation of UT for TestDecompress & TestCheckReceiveMessageOverflow in the rpc_utl_test.go
 
### Release Note: NA